### PR TITLE
mlp - typos fixed in the documentation 

### DIFF
--- a/doc/rcdaq_doc.tex
+++ b/doc/rcdaq_doc.tex
@@ -88,7 +88,7 @@
   updated to make the command shortcuts, and the GUIs show the name
   now, too. 
 \item The \verb|daq_status| used to show ``logging enabled'', and nothing if
-  disabled. So the absence of the ``enabled'' messgage indicated
+  disabled. So the absence of the ``enabled'' message indicated
   that we are not logging. That has led to a number of operator
   errors. \verb|daq_status| now shows ``enabled'' or ``disabled''. 
 \item I have added the start of the web service on the standard port
@@ -1823,7 +1823,7 @@ snapshots to the begin-run event. We also have 5 different run types defined.
 First, we let the main RCDAQ configuration script figure out if there
 is a \verb|rcdaq_server| running by issuing a \verb|daq_status|
 command and testing its return status. If that fails, we need to start
-the server. At this point, we also define the Elog wherabouts.
+the server. At this point, we also define the Elog whereabouts.
 
 \begin{verbatim} 
 #! /bin/sh


### PR DESCRIPTION
I had regressed on a few typos in the documentation . Right version merged back in.