### PR TITLE
cleanup in reset_deadtime and endrun check order

### DIFF
--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -1,5 +1,5 @@
 
-#define WRITEPRDF
+//#define WRITEPRDF
 
 #include <pthread.h>
 #include <unistd.h>

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -1,5 +1,5 @@
 
-//#define WRITEPRDF
+#define WRITEPRDF
 
 #include <pthread.h>
 #include <unistd.h>
@@ -438,6 +438,7 @@ void *shutdown_thread (void *arg)
 
   pthread_mutex_lock(&M_cout);
   cout << "shutting down... " << endl;
+  if ( TriggerH) delete TriggerH;
   pthread_mutex_unlock(&M_cout);
   sleep(2);
   exit(0);
@@ -1101,12 +1102,12 @@ void * EventLoop( void *arg)
 		  Trigger_Todo = 0;
 		  Origin ^= DAQ_TRIGGER;
 			  
+		  reset_deadtime();
 		  if (  rstatus)    // we got an endrun signal
 		    {
 		      daq_end ( std::cout);
 		      //go_on = 0;
 		    }
-		  reset_deadtime();
 		  		  
 		}
 	    }

--- a/rcdaq_runtypechooser.pl
+++ b/rcdaq_runtypechooser.pl
@@ -131,7 +131,7 @@ sub update()
     my $res = `rcdaq_client daq_get_runtype  2>&1`;
 #    print $res;
 
-    if ( $res =~ /system error/ )
+    if ( $res =~ /system error/  || $res =~ /Program not registered/ )
     {
 	$currenttypelabel->configure(-text =>"RCDAQ not running");
 


### PR DESCRIPTION
There was a sequencing issue in that I checked for an automated end and only then released the busy. It needs to the the other way around. 

Small improvement in the error checking in rcdaq_runtypechooser.pl.
