### PR TITLE
Changes in the web interface

### DIFF
--- a/control.html
+++ b/control.html
@@ -65,7 +65,8 @@ var LoggingEnabledColor      = RunActiveColor;
 var ServerDeadColor      = "#F93D5C";
 var ButtonInactiveColor  = "#666666";
 
-
+var RunCommand = "daq_begin";
+var OpenCommand = "daq_open";
 
 function init(flag)
 {
@@ -113,11 +114,13 @@ function full_parse(j)
 	    {
 		document.getElementById("OpenButton").value = "Close";
 		document.getElementById("Logging").style.backgroundColor    = LoggingEnabledColor;
+		OpenCommand = "daq_close";
 	    }
 	    else
 	    {
 		document.getElementById("OpenButton").value = "Open";
 		document.getElementById("Logging").style.backgroundColor    = LoggingDisabledColor;
+		OpenCommand = "daq_open";
 	    }
 	}
 	else if ( list[i] == "RunFlag")
@@ -132,7 +135,7 @@ function full_parse(j)
 		// console.log("setting RunActiveColor");
 		// and we change the text to "end"
 		document.getElementById("BeginButton").value = "End";
-		
+		RunCommand = "daq_end";
 	    }
 	    else
 	    {
@@ -144,6 +147,7 @@ function full_parse(j)
 		//console.log("setting RunInactiveColor");
 		// and we change the text to "Begin"
 		document.getElementById("BeginButton").value = "Begin";
+		RunCommand = "daq_begin";
 	    }
 	}
 		
@@ -223,7 +227,7 @@ function OpenHandler()
     {
 	return;
     }
-    var uri = "daq_open";
+    var uri = OpenCommand;
     var xhttp = new XMLHttpRequest();
 
     xhttp.onreadystatechange = function()
@@ -243,7 +247,7 @@ function RunHandler()
 {
     //console.log("in RunHandler");
 		     
-    var uri = "daq_begin";
+    var uri = RunCommand;
     var xhttp = new XMLHttpRequest();
 
     xhttp.onreadystatechange = function()

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -1510,10 +1510,9 @@ int rcdaq_init( pthread_mutex_t &M)
       pthread_mutex_unlock(&M_cout);
     }
    
-
-
-
-
+  //  std::ostringstream outputstream;
+  //  daq_webcontrol ( ThePort, outputstream);
+  daq_webcontrol ( ThePort);
 
 
   

--- a/rcdaq_mg_server.cc
+++ b/rcdaq_mg_server.cc
@@ -210,18 +210,34 @@ static void ev_handler(struct mg_connection *nc, int ev, void *ev_data)
 	       }
 	     return;
 	   }
-	 
-	 else if ( mg_vcmp ( &hm->uri, "/daq_open") == 0)
+
+	 else if ( mg_vcmp ( &hm->uri, "/daq_end") == 0)
 	   {
-	     //    cout << __FILE__ << " " << __LINE__ << " daq_open request" << endl;
-	     if ( get_openflag() )
+	     status = daq_end(out);
+	     if (status)
 	       {
-		 daq_close();
+		 send_status(nc,out.str() );
 	       }
 	     else
 	       {
-		 daq_open();
+		 send_nothing(nc);
+		 
 	       }
+	     return;
+	   }
+
+	 else if ( mg_vcmp ( &hm->uri, "/daq_open") == 0)
+	   {
+	     //    cout << __FILE__ << " " << __LINE__ << " daq_open request" << endl;
+	     daq_open();
+	     send_nothing(nc);
+	     return;
+	   }
+	 
+	 else if ( mg_vcmp ( &hm->uri, "/daq_close") == 0)
+	   {
+	     //    cout << __FILE__ << " " << __LINE__ << " daq_open request" << endl;
+	     daq_close();
 	     send_nothing(nc);
 	     return;
 	   }


### PR DESCRIPTION
The web controls now start on the start of the server on the default port (8899).

I changed the web sockets so that the browser javascript is aware of the run and open state,
and sends the proper daq_begin/daq_end and daq_open/daq_close command. Before the
command would toggle the state. This makes it now possible to use a curl or wget command
to trigger a specific action.