### PR TITLE
mlp - added a configure switch --enable-WRITEPRDF 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,1 @@
+configure.in

--- a/configure.in
+++ b/configure.in
@@ -15,6 +15,13 @@ AC_PROG_LIBTOOL
 AC_CHECK_HEADER([rpc/rpc.h], [ ],
                 [AC_SUBST(AM_CPPFLAGS, "$AM_CPPFLAGS -I/usr/include/tirpc")] [AC_SUBST(RPC_LDD, "-ltirpc")])
 
+dnl Example of default-disabled feature
+AC_ARG_ENABLE([WRITEPRDF],
+    AS_HELP_STRING([--enable-WRITEPRDF], [compile for legcacy PRDF version]))
+
+AS_IF([test "x$enable_WRITEPRDF" = "xyes"], [AC_DEFINE_UNQUOTED([WRITEPRDF],[1])])
+
+
 
 CXXFLAGS=" -g -O2"
 


### PR DESCRIPTION
to compile rcdaq for legacy PRDF writing that is still needed for the calorimenters and
other hardware that uses DCMs and jSEB2s. Before one had to edit rcdaq.cc
to un-comment the definition. Much easier this way.