### PR TITLE
bug fix in thread handling

### DIFF
--- a/aliases.csh
+++ b/aliases.csh
@@ -19,3 +19,4 @@ alias daq_setname                rcdaq_client  daq_setname
 alias daq_set_adaptivebuffering  rcdaq_client  daq_set_adaptivebuffering
 alias daq_shutdown               rcdaq_client  daq_shutdown
 alias daq_webcontrol             rcdaq_client  daq_webcontrol
+alias daq_get_lastfilename        rcdaq_client  daq_get_lastfilename

--- a/aliases.sh
+++ b/aliases.sh
@@ -19,3 +19,4 @@ alias daq_setname='rcdaq_client  daq_setname'
 alias daq_set_adaptivebuffering='rcdaq_client  daq_set_adaptivebuffering'
 alias daq_shutdown='rcdaq_client  daq_shutdown'
 alias daq_webcontrol='rcdaq_client daq_webcontrol'
+alias daq_get_lastfilename="rcdaq_client  daq_get_lastfilename"

--- a/doc/rcdaq_doc.tex
+++ b/doc/rcdaq_doc.tex
@@ -76,6 +76,19 @@
 
 \section{Changelog}
 
+\subsection{February 20, 2020}
+\begin{itemize}
+\item I added a command \verb|daq_get_lastfilename| (see
+  chapter~\ref{CommandOverview}) that returns the most recent (or
+  current) filename, if any. If you took a run without logging, the
+  name will be empty. The purpose of this command is for automated,
+  scripted measurements. You can obtain the last filename \emph{after}
+  the run has ended, so you can use it to start some analysis on the
+  file right away after the run ends. Before it was hard to get at
+  that filename in a script.
+
+\end{itemize}
+
 \subsection{February 13, 2019}
 \begin{itemize}
 \item I added a new built-in pseudo device \verb|device_gauss|.  Its
@@ -664,6 +677,7 @@ alias daq_setname='rcdaq_client  daq_setname'
 alias daq_set_adaptivebuffering='rcdaq_client  daq_set_adaptivebuffering'
 alias daq_shutdown='rcdaq_client  daq_shutdown'
 alias daq_webcontrol='rcdaq_client daq_webcontrol'
+alias daq_get_lastfilename="rcdaq_client  daq_get_lastfilename"
 \end{verbatim}
 
 If you routinely use a specific account for rcdaq work, you should add the 
@@ -1195,6 +1209,7 @@ as a template.
 
 
 \section{Command overview}
+\label{CommandOverview}
 
 The command \verb|rcdaq_client help| lists all available rcdaq commands:
 
@@ -1202,7 +1217,7 @@ The command \verb|rcdaq_client help| lists all available rcdaq commands:
    help                                 show this help text
    daq_status [-s] [-l]                 display status [short] [long]
    daq_open                             enable logging
-   daq_begin [run-number]              start taking data for run-number, or auto-increment
+   daq_begin [run-number]             	start taking data for run-number, or auto-increment
    daq_end                              end the run
    daq_close                            disable logging
    daq_setfilerule file-rule            set the file rule default rcdaq-%08d-%04d.evt
@@ -1214,6 +1229,7 @@ The command \verb|rcdaq_client help| lists all available rcdaq commands:
    daq_set_runtype type                 activate a predefined run type
    daq_get_runtype [-l]                 list the active runtype (if any)
    daq_list_runtypes [-s]               list defined run types
+   daq_get_lastfilename                 return the last file name written, if any
 
    daq_set_maxevents nevt               set automatic end at so many events
    daq_set_maxvolume n_MB               set automatic end at n_MB MegaByte
@@ -1221,7 +1237,7 @@ The command \verb|rcdaq_client help| lists all available rcdaq commands:
    load  shared_library_name            load a "plugin" shared library
    create_device [device-specific parameters]
 
-   daq_setname <string>               define an identifying string for this RCDAQ instance
+   daq_setname <string>                 define an identifying string for this RCDAQ instance
    daq_setrunnumberfile file            define a file to maintain the current run number
    daq_set_maxbuffersize n_KB           adjust the size of buffers written to n KB
    daq_set_adaptivebuffering seconds    enable adaptive buffering at n seconds (0 = off)
@@ -1368,6 +1384,23 @@ rcdaq_client daq_setrunnumberfile $HOME/.last_rcdaq_runnumber.txt
   you should leave the adaptive buffering switched on. Setting the
   time to 0 disables adaptive buffering.
 
+\item[daq\_get\_lastfilename] This returns the filename of the last
+  written file, if any (if logging was disabled in the most recent
+  run, you get an empty string). The purpose of this command is for
+  automated, scripted measurements. You can obtain the last filename
+  \emph{after} the run has ended, so you can use it to start some
+  analysis on the file right away after the run ends. Here is an example:
+
+\begin{verbatim}
+while (some_condition) ; do 
+    rcdaq_client daq_begin
+    wait_for_run_end.sh                       # wait until the run automatically ends 
+    FILE=$(rcdaq_client daq_get_lastfilename) # get the filename, if any 
+    # if there was a file, start the analysis, presumably in the background
+    [ -n "$FILE" ] && start_analysis $FILE
+done
+\end{verbatim}
+  
 \item[daq\_webcontrol port\_number ] Start the web-based controls on
   the given port number (defaults to port 8899 if omitted). See
   chapter~\ref{webcontrols} for details.

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -1731,7 +1731,7 @@ int daq_webcontrol(const int port, std::ostream& os)
 
 int daq_getlastfilename( std::ostream& os)
 {
-
+  if (get_previous_filename().empty() ) return -1;
   os <<  get_previous_filename() << endl;
   return 0;
 

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -87,6 +87,7 @@ static std::map<string,string> RunTypes;
 
 static std::string TheFileRule = "rcdaq-%08d-%04d.evt";
 static std::string CurrentFilename = "";
+static std::string PreviousFilename = "";
 
 static std::string TheRunnumberfile = " ";
 static int RunnumberfileIsSet = 0;
@@ -427,6 +428,7 @@ int open_file(const int run_number, int *fd)
 
   *fd = ifd;
   CurrentFilename = d;
+  PreviousFilename = CurrentFilename;
 
   file_is_open =1;
 
@@ -843,6 +845,11 @@ std::string& get_current_filename()
   return CurrentFilename;
 }
 
+std::string& get_previous_filename()
+{
+  return PreviousFilename;
+}
+
 int daq_begin(const int irun, std::ostream& os)
 {
   if ( Daq_Status & DAQ_RUNNING ) 
@@ -991,6 +998,7 @@ int daq_end(std::ostream& os)
   run_volume = 0;    // volume in longwords 
   BytesInThisRun = 0;    // bytes actually written
   Buffer_number = 0;
+  PreviousFilename = CurrentFilename;
   CurrentFilename = "";
   StartTime = 0;
   return 0;
@@ -1720,6 +1728,15 @@ int daq_webcontrol(const int port, std::ostream& os)
   return 0;
 
 }
+
+int daq_getlastfilename( std::ostream& os)
+{
+
+  os <<  get_previous_filename() << endl;
+  return 0;
+
+}
+
 
 int daq_running()
 {

--- a/rcdaq.h
+++ b/rcdaq.h
@@ -81,6 +81,8 @@ int daq_load_plugin( const char *sharedlib, std::ostream& os);
 
 int daq_webcontrol(const int port,std::ostream& os = std::cout );
 
+int daq_getlastfilename(std::ostream& os = std::cout );
+
 
 int get_runnumber();
 int get_oldrunnumber();

--- a/rcdaq_actions.h
+++ b/rcdaq_actions.h
@@ -32,6 +32,8 @@
 #define DAQ_SETNAME       124
 #define DAQ_GETNAME       125
 
+#define DAQ_GETLASTFILENAME    126
+
 
 
 #define DAQ_DEVICE_RANDOM         1001

--- a/rcdaq_client.cc
+++ b/rcdaq_client.cc
@@ -55,20 +55,23 @@ void showHelp()
   std::cout << "   daq_set_runtype type                 activate a predefined run type" << std::endl;
   std::cout << "   daq_get_runtype [-l]                 list the active runtype (if any)" << std::endl;
   std::cout << "   daq_list_runtypes [-s]               list defined run types" << std::endl;
+  std::cout << "   daq_get_lastfilename                 return the last file name written, if any" << std::endl;
   std::cout << std::endl; 
+
   std::cout << "   daq_set_maxevents nevt               set automatic end at so many events" << std::endl;
   std::cout << "   daq_set_maxvolume n_MB               set automatic end at n_MB MegaByte" << std::endl;
   std::cout << std::endl; 
+
   std::cout << "   load  shared_library_name            load a \"plugin\" shared library" << std::endl;
   std::cout << "   create_device [device-specific parameters] " << std::endl;
   std::cout << std::endl; 
-  std::cout << "   daq_setname <string>               define an identifying string for this RCDAQ instance" << std::endl;
+
+  std::cout << "   daq_setname <string>                 define an identifying string for this RCDAQ instance" << std::endl;
   std::cout << "   daq_setrunnumberfile file            define a file to maintain the current run number" << std::endl;
-
-
   std::cout << "   daq_set_maxbuffersize n_KB           adjust the size of buffers written to n KB" << std::endl;
   std::cout << "   daq_set_adaptivebuffering seconds    enable adaptive buffering at n seconds (0 = off)" << std::endl;
   std::cout << std::endl; 
+
   std::cout << "   daq_webcontrol <port number>         restart web controls on a new port (default 8080)" << std::endl;
   std::cout << std::endl; 
   std::cout << "   elog elog-server port                specify coordinates for an Elog server" << std::endl;
@@ -573,7 +576,7 @@ int command_execute( int argc, char **argv)
  
     }
 
-  else if ( strcasecmp(command,"daq_getlastfilename") == 0)
+  else if ( strcasecmp(command,"daq_get_lastfilename") == 0)
     {
 
       ab.action = DAQ_GETLASTFILENAME;

--- a/rcdaq_client.cc
+++ b/rcdaq_client.cc
@@ -573,6 +573,22 @@ int command_execute( int argc, char **argv)
  
     }
 
+  else if ( strcasecmp(command,"daq_getlastfilename") == 0)
+    {
+
+      ab.action = DAQ_GETLASTFILENAME;
+
+      ab.ipar[0] = 0;
+
+      r = r_action_1 (&ab, clnt);
+      if (r == (shortResult *) NULL) 
+	{
+	  clnt_perror (clnt, "call failed");
+	}
+      if (r->content) std::cout <<  r->str << std::flush;
+ 
+    }
+
   else if ( strcasecmp(command,"elog") == 0)
     {
 

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -735,7 +735,7 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
 
     case DAQ_GETLASTFILENAME:
       result.status = daq_getlastfilename ( outputstream);
-      if ( outputstream.str().size() == 0 )
+      if ( result.status )
 	{
 	  pthread_mutex_unlock(&M_output);
 	  result.content = 0;

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -733,6 +733,21 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       return &result;
       break;
 
+    case DAQ_GETLASTFILENAME:
+      result.status = daq_getlastfilename ( outputstream);
+      if ( outputstream.str().size() == 0 )
+	{
+	  pthread_mutex_unlock(&M_output);
+	  result.content = 0;
+	  return &result;
+	}
+      outputstream.str().copy(resultstring,outputstream.str().size());
+      resultstring[outputstream.str().size()] = 0;
+      result.str = resultstring;
+      result.content = 1;
+      pthread_mutex_unlock(&M_output);
+      return &result;
+      break;
 
     default:
       strcpy(resultstring, "Unknown action");


### PR DESCRIPTION
The previous commit to replace the mutexes with semaphores was premature. I could trace the
error the that lead to a crash to a missing return statement of a non-void function (daq_triggerloop). We will try this one.

Along the way I have changed the Event number reporting. Previously we got the event number of the *next* event that was to be triggered. That has led to some confusion - if you didn't get any events, the number would be 2 (next after the begun-run event), and users assumed that the readout stalled when there was just no trigger.  Now we report the event number that has actually been read.