### PR TITLE
Implementation of the sfs, fast end, changes to web socket interfaces

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ librcdaqplugin_gauss_la_SOURCES = daq_device_gauss.cc gauss_plugin.cc simpleRand
 
 bin_SCRIPTS =  rcdaq_control.pl rcdaq_status.pl rcdaq_runtypechooser.pl rcdaq_configmenu.pl aliases.csh aliases.sh automated_run_example.sh wait_for_run_end.sh
 
-bin_PROGRAMS =  rcdaq_client rcdaq_server elogtest
+bin_PROGRAMS =  rcdaq_client rcdaq_server elogtest sfs
 
 elogtest_SOURCES = elogtest.cc
 elogtest_LDADD = eloghandler.lo 
@@ -113,8 +113,8 @@ rcdaq_server_LDADD = librcdaq.la rcdaq_rpc_svc.lo rcdaq_rpc_xdr.lo eloghandler.l
 
 rcdaq_server_LDFLAGS =  -Wl,-export-dynamic
 
-#rcdaq_sa_SOURCES = rcdaq_frontend.cc 
-#rcdaq_sa_LDADD =  librcdaq.la -lpthread
+sfs_SOURCES = sfs.cc 
+sfs_LDADD = -lpthread 
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# data_acquisition
+# RCDAQ
 This is the repository for the RCDAQ data acquisition system.
 
 RCDAQ is a DAQ system in use at the Brookhaven Lab's sPHENIX experiment, and for a number of R&D efforts for the future Electron-Ion Collider. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # data_acquisition
-This is the DAQ repository for the time being. It will host rcdaq and the plugins.
+This is the repository for the RCDAQ data acquisition system.
 
-I will try to import the existing git repository where rcdaq and the plugins have been maintained for a long time.
-Let's see if that works. I don't want to loose several years worth of history.
-
-It didn't come out the way I wanted... I wanted data_acqusition/rcdaq etc. Next try.
-
+RCDAQ is a DAQ system in use at the Brookhaven Lab's sPHENIX experiment, and for a number of R&D efforts for the future Electron-Ion Collider. 

--- a/control.html
+++ b/control.html
@@ -147,7 +147,7 @@ function init()
 	document.getElementById("Volume").textContent="n/a";
 	document.getElementById("Logging").textContent=" ";
 
-	retryTimer = setTimeout(init, 5000);
+	retryTimer = setTimeout(init, 2500);
     }
     if ( stopMe) return;
 

--- a/control.html
+++ b/control.html
@@ -180,7 +180,7 @@ function full_parse(j)
     {
 	if ( list[i] == "OpenFlag")
 	{
-	    if ( o[list[i]] == 1 ) 
+	    if ( o[list[i]] > 0  ) 
 	    {
 		document.getElementById("OpenButton").value = "Close";
 		document.getElementById("Logging").className='LoggingActive';

--- a/daqBuffer.h
+++ b/daqBuffer.h
@@ -14,6 +14,17 @@
 #define PRDFBUFFERHEADER 0xffffffc0;
 #define ONCSBUFFERHEADER 0xffffc0c0;
 
+#define CTRL_BEGINRUN        1
+#define CTRL_ENDRUN          2
+#define CTRL_DATA            3
+#define CTRL_CLOSE           4
+#define CTRL_SENDFILENAME    5
+
+#define CTRL_REMOTESUCCESS 100
+#define CTRL_REMOTEFAIL    101
+
+
+
 class daqBuffer {
 
 public:
@@ -39,6 +50,9 @@ public:
   // now the write routine
   unsigned int writeout ( int fd);
 
+  // now the "send buffer to a server" routine
+  unsigned int sendout ( int fd );
+  
   // now the "send monitor data" routine
   unsigned int sendData ( int fd, const int max_length);
 

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -846,6 +846,8 @@ int daq_begin(const int irun, std::ostream& os)
       return -1;
     }
 
+  // set the status to "running"
+  Daq_Status |= DAQ_RUNNING;
 
   if (  irun ==0)
     {
@@ -871,6 +873,7 @@ int daq_begin(const int irun, std::ostream& os)
       else
 	{
 	  os << "Could not open output file - Run " << TheRun << " not started" << endl;;
+	  Daq_Status ^= DAQ_RUNNING;
 	  return -1;
 	}
     }
@@ -878,8 +881,6 @@ int daq_begin(const int irun, std::ostream& os)
   Buffer_number = 1;
   Event_number  = 1;
   
-  // set the status to "running"
-  Daq_Status |= DAQ_RUNNING;
 
   // just to be safe, clear the "end requested" bit
   if ( Daq_Status & DAQ_ENDREQUESTED ) Daq_Status ^= DAQ_ENDREQUESTED;
@@ -908,6 +909,7 @@ int daq_begin(const int irun, std::ostream& os)
 	  os << "Cannot start run - event sizes larger than buffer, size " 
 	     <<  wantedmaxsize/1024 << " Buffer size " 
 	     << transportBuffer->getMaxSize()/1024 << endl;
+	  Daq_Status ^= DAQ_RUNNING;
 	  return -1;
 	}
       //      os << " Buffer size increased to " << transportBuffer->getMaxSize()/1024 << " KB"<< endl;
@@ -946,8 +948,8 @@ int daq_begin(const int irun, std::ostream& os)
   enable_trigger();
 
 
-  os << "Run " << TheRun << " started" << endl;;
-	  
+  os << "Run " << TheRun << " started" << endl;
+
   return 0;
 }
 
@@ -1123,7 +1125,6 @@ void * EventLoop( void *arg)
 			  
 	      if (  rstatus)    // we got an endrun signal
 		{
-		  cout << __LINE__ << "  " << __FILE__ << " internal end-run requested"  << endl;
 		  TriggerControl = 0;
 		  reset_deadtime();
 

--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -980,7 +980,6 @@ int daq_end(std::ostream& os)
       return -1;
     }
   disable_trigger();
-  Daq_Status ^= DAQ_RUNNING;
   device_endrun();
 
   readout(ENDRUNEVENT);
@@ -1015,6 +1014,7 @@ int daq_end(std::ostream& os)
   PreviousFilename = CurrentFilename;
   CurrentFilename = "";
   StartTime = 0;
+  Daq_Status ^= DAQ_RUNNING;
   return 0;
 }
 

--- a/rcdaq.h
+++ b/rcdaq.h
@@ -79,6 +79,7 @@ int daq_set_eloghandler( const char *host, const int port, const char *logname);
 
 int daq_load_plugin( const char *sharedlib, std::ostream& os);
 
+int daq_wait_for_actual_end();
 
 // functions for the webserver
 

--- a/rcdaq.h
+++ b/rcdaq.h
@@ -49,15 +49,20 @@ std::string& daq_get_filerule();
 int daq_open(std::ostream& os = std::cout);
 int daq_shutdown(const unsigned long servernumber, const unsigned long versionnumber,
 		 std::ostream& os = std::cout);
-
+std::string& get_current_filename();
+int daq_close (std::ostream& os = std::cout);
 int is_open();
+
+int daq_open_server (const char *hostname, const int port, std::ostream& os = std::cout);
+int is_server_open();
+int daq_server_close (std::ostream& os = std::cout);
+int get_serverflag();
+
 
 int daq_set_name(const char *name);
 int daq_get_name(std::ostream& os = std::cout);
 std::string daq_get_myname();
 
-std::string& get_current_filename();
-int daq_close (std::ostream& os = std::cout);
 
 int daq_list_readlist(std::ostream& os = std::cout );
 int daq_clear_readlist(std::ostream& os = std::cout);

--- a/rcdaq.h
+++ b/rcdaq.h
@@ -14,7 +14,7 @@ void set_eventsizes();
 void *writebuffers ( void * arg);
 void *EventLoop( void *arg);
 
-int daq_end();
+//int daq_end();
 int Command( const int command);
 
 
@@ -27,7 +27,10 @@ int rcdaq_init(pthread_mutex_t &M );
 int add_readoutdevice( daq_device *d);
 
 int daq_begin(const int irun,std::ostream& os = std::cout );
+
+int daq_end_immediate(std::ostream& os = std::cout);
 int daq_end(std::ostream& os = std::cout);
+
 int daq_fake_trigger (const int n, const int waitinterval);
 
 int daq_write_runnumberfile(const int run);

--- a/rcdaq_actions.h
+++ b/rcdaq_actions.h
@@ -34,6 +34,8 @@
 
 #define DAQ_GETLASTFILENAME    126
 
+#define DAQ_END_IMMEDIATE      127
+
 
 
 #define DAQ_DEVICE_RANDOM         1001

--- a/rcdaq_actions.h
+++ b/rcdaq_actions.h
@@ -36,6 +36,8 @@
 
 #define DAQ_END_IMMEDIATE      127
 
+#define DAQ_OPEN_SERVER        128
+
 
 
 #define DAQ_DEVICE_RANDOM         1001

--- a/rcdaq_client.cc
+++ b/rcdaq_client.cc
@@ -43,6 +43,7 @@ void showHelp()
   std::cout << "   help                                 show this help text"  << std::endl; 
   std::cout << "   daq_status [-s] [-l]                 display status [short] [long]" << std::endl;
   std::cout << "   daq_open                             enable logging" << std::endl;
+  std::cout << "   daq_open_server hostname [port]      enable logging to server" << std::endl;
   std::cout << "   daq_begin [run-number]             	start taking data for run-number, or auto-increment" << std::endl;
   std::cout << "   daq_end                              end the run " << std::endl;
   std::cout << "   daq_close                            disable logging" << std::endl;
@@ -421,6 +422,29 @@ int command_execute( int argc, char **argv)
 	}
       if (r->content) std::cout <<  r->str << std::flush;
  
+    }
+
+  else if ( strcasecmp(command,"daq_open_server") == 0)
+    {
+      
+      if ( argc <  optind + 2) return -1;
+
+      ab.action = DAQ_OPEN_SERVER;
+      ab.spar = argv[optind + 1];
+      if ( argc == optind + 3)
+	{
+	  ab.ipar[0] = get_value(argv[optind + 2]);
+	}
+      else
+	{
+	  ab.ipar[0] = 0;
+	}
+      r = r_action_1(&ab, clnt);
+      if (r == (shortResult *) NULL) 
+	{
+	  clnt_perror (clnt, "call failed");
+	}
+      if (r->content) std::cout <<  r->str << std::flush;
     }
   
   else if ( strcasecmp(command,"daq_close") == 0)

--- a/rcdaq_client.cc
+++ b/rcdaq_client.cc
@@ -180,13 +180,14 @@ int command_execute( int argc, char **argv)
   // the log and short flags are for qualifying the 
   // status output
   int long_flag = 1;
+  int immediate_flag = 0;  // only used for daq_end so far
 
   int c;
   
   optind = 0; // tell getopt to start over
   int servernumber=0;
 
-  while ((c = getopt(argc, argv, "vls")) != EOF)
+  while ((c = getopt(argc, argv, "vlsi")) != EOF)
     {
       switch (c) 
 	{
@@ -201,6 +202,10 @@ int command_execute( int argc, char **argv)
 
 	case 's': // set the short flag (0) (note that long_flag is pre-set to 1 for "normal") 
 	  long_flag=0;
+	  break;
+
+	case 'i': // set the "immediate" flag; onoy used in daq_end to request an asynchronous end
+	  immediate_flag=1;
 	  break;
 
 	}
@@ -267,7 +272,15 @@ int command_execute( int argc, char **argv)
   else if ( strcasecmp(command,"daq_end") == 0)
     {
 
-      ab.action = DAQ_END;
+      if (immediate_flag)
+	{
+	  ab.action = DAQ_END_IMMEDIATE;
+	}
+      else
+	{
+	  ab.action = DAQ_END;
+	}
+      
       r = r_action_1(&ab, clnt);
       if (r == (shortResult *) NULL) 
 	{

--- a/rcdaq_control.pl
+++ b/rcdaq_control.pl
@@ -208,10 +208,13 @@ sub update()
 	    }
 	    
 	    
-	    if ( $openflag )
-	    {
-		
+	    if ( $openflag == 1)
+	    {		
 		$filenamelabel->configure(-text =>"Logging enabled");
+	    }
+	    elsif ( $openflag == 2)
+	    {		
+		$filenamelabel->configure(-text =>"Logging enabled (Server)");
 	    }
 	    else
 	    {
@@ -229,10 +232,13 @@ sub update()
 	    $button_open->configure(-bg => $graycolor );
 	    $button_open->configure(-command => [\&dummy] );
 	    
-	    if ( $openflag )
+	    if ( $openflag == 1 )
 	    {
-		
 		$filenamelabel->configure(-text =>"File: $fn");
+	    }
+	    elsif ( $openflag ==2 )
+	    {
+		$filenamelabel->configure(-text =>"File on server: $fn");
 	    }
 	    else
 	    {

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -470,6 +470,10 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
   static int currentmaxresultlength = 10*2048;
   static char *resultstring = new char[currentmaxresultlength+1];
 
+  // to avoid a race condition with the asynchronous "end requested" feature,
+  // wait here...
+  daq_wait_for_actual_end();
+
   
   if ( outputstream.str().size() > currentmaxresultlength )
     {

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -517,6 +517,17 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       return &result;
       break;
 
+    case DAQ_END_IMMEDIATE:
+        // cout << "daq_end "  << endl;
+      result.status = daq_end_immediate(outputstream);
+      outputstream.str().copy(resultstring,outputstream.str().size());
+      resultstring[outputstream.str().size()] = 0;
+      result.str = resultstring;
+      result.content = 1;
+      pthread_mutex_unlock(&M_output);
+      return &result;
+      break;
+
     case DAQ_RUNNUMBERFILE:
       daq_set_runnumberfile(ab->spar);
       break;

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -500,7 +500,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
     {
       
     case DAQ_BEGIN:
-      //  cout << "daq_begin " << ab->ipar[0] << endl;
       result.status = daq_begin (  ab->ipar[0], outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -511,7 +510,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_END:
-        // cout << "daq_end "  << endl;
       result.status = daq_end(outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -522,7 +520,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_END_IMMEDIATE:
-        // cout << "daq_end "  << endl;
       result.status = daq_end_immediate(outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -573,7 +570,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_LISTRUNTYPES:
-      // cout << "daq_list_runtypes "  << endl;
       result.status = daq_list_runtypes(ab->ipar[0], outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -595,7 +591,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
 
       
     case DAQ_OPEN:
-      // cout << "daq_open " << ab->spar << endl;
       result.status = daq_open(outputstream);
       if (result.status) 
 	{
@@ -608,8 +603,20 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       return &result;
       break;
 
+    case DAQ_OPEN_SERVER:
+      result.status = daq_open_server(ab->spar, ab->ipar[0], outputstream);
+      if (result.status) 
+	{
+	  outputstream.str().copy(resultstring,outputstream.str().size());
+	  resultstring[outputstream.str().size()] = 0;
+	  result.str = resultstring;
+	  result.content = 1;
+	}
+      pthread_mutex_unlock(&M_output);
+      return &result;
+      break;
+
     case DAQ_CLOSE:
-      // cout << "daq_close "  << endl;
       result.status = daq_close(outputstream);
       if (result.status) 
 	{
@@ -623,12 +630,10 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_FAKETRIGGER:
-      // cout << "daq_fake_trigger "  << endl;
       result.status =  daq_fake_trigger (ab->ipar[0], ab->ipar[1]);
       break;
 
     case DAQ_LISTREADLIST:
-      // cout << "daq_list_readlist "  << endl;
       result.status = daq_list_readlist(outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -639,7 +644,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_CLEARREADLIST:
-      // cout << "daq_clear_readlist "  << endl;
       result.status = daq_clear_readlist(outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -650,8 +654,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_STATUS:
-
-      //      cout << "daq_status "  << endl;
       result.status = daq_status(ab->ipar[0], outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;
@@ -662,7 +664,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_SETMAXEVENTS:
-      //  cout << "daq_setmaxevents " << ab->ipar[0] << endl;
       result.status = daq_setmaxevents (  ab->ipar[0], outputstream);
       if (result.status) 
 	{
@@ -676,7 +677,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_SETMAXVOLUME:
-      //  cout << "daq_setmaxvolume " << ab->ipar[0] << endl;
       result.status = daq_setmaxvolume (  ab->ipar[0], outputstream);
       if (result.status) 
 	{
@@ -690,7 +690,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_SETMAXBUFFERSIZE:
-      //  cout << "daq_setmaxvolume " << ab->ipar[0] << endl;
       result.status = daq_setmaxbuffersize (  ab->ipar[0], outputstream);
       if (result.status) 
 	{
@@ -704,7 +703,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_SETADAPTIVEBUFFER:
-      //  cout << "daq_setmaxevents " << ab->ipar[0] << endl;
       result.status = daq_setadaptivebuffering (  ab->ipar[0], outputstream);
       if (result.status) 
 	{
@@ -719,12 +717,10 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
 
 
     case DAQ_ELOG:
-      // cout << "daq_elog " << ab->spar << "  " << ab->ipar[0] << endl;
       daq_set_eloghandler( ab->spar,  ab->ipar[0], ab->spar2);
       break;
 
     case DAQ_LOAD:
-      // 
       result.status = daq_load_plugin( ab->spar, outputstream );
       if (result.status) 
 	{
@@ -738,7 +734,6 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_WEBCONTROL:
-      //  cout << "daq_begin " << ab->ipar[0] << endl;
       result.status = daq_webcontrol (  ab->ipar[0], outputstream);
       outputstream.str().copy(resultstring,outputstream.str().size());
       resultstring[outputstream.str().size()] = 0;

--- a/rcdaq_status.pl
+++ b/rcdaq_status.pl
@@ -199,10 +199,13 @@ sub update()
 		$runstatuslabel->configure(-text =>"Stopped   Run $old_run");
 	    }
 		
-	    if ( $openflag )
-	    {
-		
+	    if ( $openflag == 1)
+	    {		
 		$filenamelabel->configure(-text =>"Logging enabled");
+	    }
+	    elsif ( $openflag == 2)
+	    {		
+		$filenamelabel->configure(-text =>"Logging enabled (Server)");
 	    }
 	    else
 	    {
@@ -215,10 +218,13 @@ sub update()
 	    
 	    $runstatuslabel->configure(-text =>"Running for $duration s");
 	    
-	    if ( $openflag )
+ 	    if ( $openflag == 1 )
 	    {
-		
 		$filenamelabel->configure(-text =>"File: $fn");
+	    }
+	    elsif ( $openflag ==2 )
+	    {
+		$filenamelabel->configure(-text =>"File on server: $fn");
 	    }
 	    else
 	    {

--- a/sfs.cc
+++ b/sfs.cc
@@ -1,0 +1,624 @@
+
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <dlfcn.h>
+#include <sys/ipc.h>
+
+#include <pthread.h>
+
+#ifdef HAVE_BSTRING_H
+#include <bstring.h>
+#else
+#include <strings.h>
+#endif
+
+#include <sys/time.h>
+
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netdb.h> 
+
+#include <sys/wait.h>
+#include <sys/resource.h>
+
+
+#include <sys/types.h>
+
+#ifdef SunOS
+#include <sys/filio.h>
+#endif
+
+#include <sys/stat.h>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/ioctl.h>
+
+#include <stdio.h>
+#include <iostream>
+#include <iomanip>
+
+#ifdef HAVE_GETOPT_H
+#include <getopt.h>
+#endif
+
+//#include <Event/BufferConstants.h>
+//#include <Event/A_Event.h>
+
+#include <Event/buffer.h>
+
+
+#define CTRL_BEGINRUN        1
+#define CTRL_ENDRUN          2
+#define CTRL_DATA            3
+#define CTRL_CLOSE           4
+#define CTRL_SENDFILENAME    5
+
+#define CTRL_REMOTESUCCESS 100
+#define CTRL_REMOTEFAIL    101
+
+#define ROLE_RECEIVED 0
+#define ROLE_WRITTEN  1
+
+
+
+// initial size 16 Mbytes ( /4 in int units)
+#define INITIAL_SIZE (4*1024*1024)
+
+
+typedef struct 
+{
+  int dirty;
+  int role;
+  int bytecount;
+  int buffersize;
+  PHDWORD *bf;
+} bufferstructure;
+
+int run_number = 0;
+int verbose = 0;
+int sockfd = 0;
+int dd_fd = 0;
+
+
+pthread_mutex_t M_cout;
+
+pthread_mutex_t M_write;
+pthread_mutex_t M_done;
+
+
+pthread_t ThreadId;
+pthread_t       tid;
+int output_fd = -1;
+
+int the_port = 5001;
+
+int RunIsActive = 0; 
+int NumberWritten = 0; 
+int file_open = 0;
+
+
+int readn(int , char *, int);
+int writen(int , char *, int);
+
+#if defined(SunOS) || defined(Linux) 
+void sig_handler(int);
+#else
+void sig_handler(...);
+#endif
+
+void *writebuffers ( void * arg);
+int handle_this_child( pid_t pid);
+in_addr_t find_address_from_interface(const char *);
+
+void cleanup(const int exitstatus);
+
+
+bufferstructure *bf_being_received;
+bufferstructure *bf_being_written;
+ 
+
+using namespace std;
+
+
+void exitmsg()
+{
+  cout << "** This is the Advanced Multithreaded Server. No gimmicks. Pure Power." << endl;
+  cout << "** usage: sfs  port-number" << endl;
+  cout << "   -d enable database logging" << endl;
+  cout << "   -b interface    bind to this interface" << endl;
+  exit(0);
+}
+
+
+//char *s_opcode[] = {
+//		    "Invalid code",
+//		    "CTRL_BEGINRUN",
+//		    "CTRL_ENDRUN",
+//		    "CTRL_DATA",
+//		    "CTRL_CLOSE",
+//		    "CTRL_SENDFILENAME"};
+		    
+
+int main( int argc, char* argv[])
+{
+
+  int status;
+
+
+#if defined(SunOS) || defined(Linux) 
+  struct sockaddr client_addr;
+#else
+  struct sockaddr_in client_addr;
+#endif
+  struct sockaddr_in server_addr;
+
+#if defined(SunOS)
+  int client_addr_len = sizeof(client_addr);
+#else
+  unsigned int client_addr_len = sizeof(client_addr);
+#endif
+
+  pthread_mutex_init(&M_cout, 0); 
+  pthread_mutex_init(&M_write, 0); 
+  pthread_mutex_init(&M_done, 0); 
+
+  pthread_mutex_lock(&M_write);
+
+  // by default, we listen on all interfaces
+  in_addr_t listen_address = htonl(INADDR_ANY);  
+
+  char c;
+  
+  while ((c = getopt(argc, argv, "vdb:")) != EOF)
+    {
+      switch (c) 
+	{
+
+	case 'v':   // verbose
+	  verbose += 1;
+	  break;
+
+	case 'b':   // bind to this interface
+	  listen_address = find_address_from_interface(optarg);
+	  break;
+
+	case 'd':   // no database
+	  // databaseflag=1;
+	  // cout << "database access enabled" << endl;
+	  break;
+
+
+	}
+    }
+
+
+
+  if (argc >= optind)
+    {
+      sscanf (argv[optind],"%d", &the_port);
+    }
+  
+  // ------------------------
+  // now set up the sockets
+
+  if ( (sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0 ) 
+    {
+      cleanup(1);
+    }
+  //  int xs = 64*1024+21845;
+  int xs = 1024*1024;
+
+  int s = setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF,
+		     &xs, 4);
+
+
+  memset( &server_addr, 0, sizeof(server_addr));
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_addr.s_addr = listen_address;
+  server_addr.sin_port = htons(the_port);
+
+  int i;
+  
+  if ( ( i = bind(sockfd, (struct sockaddr*) &server_addr, sizeof(server_addr))) < 0 )
+    {
+      perror(" bind ");
+      cleanup(1);
+    }
+
+  if ( ( i =  listen(sockfd, 25) ) )
+    {
+      perror(" listen ");
+      cleanup(1);
+    }
+    
+
+  signal(SIGCHLD, SIG_IGN); 
+
+  pid_t pid;
+  struct sockaddr_in out;
+  
+  while  (sockfd > 0)
+    {
+			
+      client_addr_len = sizeof(out); 
+      dd_fd = accept(sockfd,  (struct sockaddr *) &out, &client_addr_len);
+      if ( dd_fd < 0 ) 
+	{
+	  pthread_mutex_lock(&M_cout);
+	  cout  << "error in accept socket" << endl;
+	  pthread_mutex_unlock(&M_cout);
+	  perror (" accept" );
+	  cleanup(1);
+	  exit(1);
+	}
+
+
+      if (verbose)
+	{
+	  char *host = new char[512]; 
+	  getnameinfo((struct sockaddr *) &out, sizeof(struct sockaddr_in), host, 511,
+		      NULL, 0, NI_NOFQDN); 
+    	  cout << " new connection from " << host << endl;
+	}
+      
+      
+      if ( (pid = fork()) == 0 ) 
+	{
+	  handle_this_child( pid);
+	}
+    }
+}
+
+int handle_this_child( pid_t pid)
+{
+
+
+  int controlword;
+  int len;
+  int local_runnr = 0;
+
+  bufferstructure B0;
+  bufferstructure B1;
+  
+  bf_being_received = &B0;
+  bf_being_written = &B1;
+  bufferstructure *bf_temp;
+
+  B0.bf = new PHDWORD[INITIAL_SIZE];
+  B0.buffersize = INITIAL_SIZE;
+  B0.dirty = 0;
+  B0.role= ROLE_RECEIVED;
+  B0.bytecount = 0;
+		      
+  B1.bf = new PHDWORD[INITIAL_SIZE];
+  B1.buffersize = INITIAL_SIZE;
+  B1.dirty = 0;
+  B1.role= ROLE_RECEIVED;
+  B1.bytecount = 0;
+		      
+  int i;
+  
+  // we make a thread tht will write out our buffers
+  i = pthread_create(&ThreadId, NULL, 
+		     writebuffers, 
+		     (void *) 0);
+  if (i )
+    {
+      cout << "error in thread create " << i << endl;
+      perror("Thread ");
+      cleanup(1);
+    }
+  // else
+  //   {
+  //     pthread_mutex_lock(&M_cout); 
+  //     cout << "write thread created" << endl;
+  //     pthread_mutex_unlock(&M_cout);
+  //   }
+    
+  // should be the default, but set it to blocking mode anyway
+  i = ioctl (dd_fd,  FIONBIO, 0);
+    
+  // find out where we were contacted from
+    
+
+  int status;
+  int xx;
+
+  int go_on = 1;
+  while ( go_on)
+    {
+      if ( (status = readn (dd_fd, (char *) &xx, 4) ) <= 0)
+	{
+	  cout  << "error in read from socket" << endl;
+	  perror ("read " );
+	  cleanup(1);
+	  exit(1);
+	}
+	
+      controlword = ntohl(xx);
+
+      // cout << endl;
+      // cout << __FILE__ << " " << __LINE__  << " controlword = " << controlword << " ntew: " << xx << " " ;
+      // if ( controlword >=0 && controlword <=5) cout  << s_opcode[controlword];
+      // cout << endl;
+	
+      char *p;
+      char filename[1024];
+      int value, len;
+      
+      switch (controlword) 
+	{
+
+	case  CTRL_SENDFILENAME:
+	  // read the length of what we are about to get 
+	  readn (dd_fd, (char *) &len, sizeof(int));
+	  len  = ntohl(len);
+	  // acknowledge... or not
+	  //cout  << " filename len  = " << len << endl;
+	  if ( len >= 1023)
+	    {
+	      i = htonl(CTRL_REMOTEFAIL);
+	      writen (dd_fd, (char *)&i, 4);
+	      break;
+	    }
+	  value = readn (dd_fd, filename, len);
+	  filename[value] = 0;
+	  //cout  << " filename is " << filename << endl;
+
+          i = htonl(CTRL_REMOTESUCCESS);
+          writen (dd_fd, (char *)&i, 4);
+	  
+	  break;
+	  
+	case  CTRL_BEGINRUN:
+	  
+	  readn (dd_fd, (char *) &local_runnr, 4);
+	  local_runnr = ntohl(local_runnr);
+	  //cout  << " runnumber = " << local_runnr << endl;
+
+	  output_fd =  open(filename,  O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_LARGEFILE , 
+			    S_IRWXU | S_IROTH | S_IRGRP );
+	  if (output_fd < 0) 
+	    {
+	      cerr << "file " << filename << " exists, I will not overwrite " << endl;
+	      i = htonl(CTRL_REMOTEFAIL);
+	      writen (dd_fd, (char *)&i, 4);
+	      break;
+	    }
+    
+	  bf_being_received = &B0;
+	  bf_being_written = &B1;
+	    
+	  bf_being_received->role = ROLE_RECEIVED;
+	  bf_being_received->dirty=0;
+	    
+	  bf_being_written->role = ROLE_WRITTEN;
+	  bf_being_written->dirty = 0;
+	    
+	  i = htonl(CTRL_REMOTESUCCESS);
+	  writen (dd_fd, (char *)&i, 4);
+	  
+	  break;
+	  
+	case  CTRL_ENDRUN:
+	  //cout  << " endrun signal " << endl;
+	  
+	  pthread_mutex_lock(&M_done);
+	  close (output_fd);
+	  i = htonl(CTRL_REMOTESUCCESS);
+	  writen (dd_fd, (char *)&i, 4);
+	  pthread_mutex_unlock(&M_done);
+
+	  break;
+	  
+	case  CTRL_DATA:
+	  status = readn (dd_fd, (char *) &len, 4);
+	  len = ntohl(len);
+	  //cout  << " data! len = " << len << endl;
+	  
+	  bf_being_received->bytecount = len;
+	  if ( (len+3)/4 > bf_being_received->buffersize)
+	    { 
+	      delete [] bf_being_received->bf;
+	      bf_being_received->buffersize = (len+3)/4 + 2048;
+	      
+	      pthread_mutex_lock(&M_cout);
+	      //	      cout << "expanding buffer to " << bf_being_received->buffersize << " for host " << host << endl;
+	      pthread_mutex_unlock(&M_cout);
+	      
+	      bf_being_received->bf = new PHDWORD[ bf_being_received->buffersize];
+	    }
+	  
+	  p = (char *) bf_being_received->bf;
+	  status = readn (dd_fd, p,   len );
+	  if ( len != status)
+	    {
+	      
+	      pthread_mutex_lock(&M_cout);
+	      //	      cout << "error on transfer: Expected " << len 
+	      //	   << " got status  " << status  << "  for host " << host << endl;
+	      perror("ctrl_data");
+	      pthread_mutex_unlock(&M_cout);
+	      i = htonl(CTRL_REMOTEFAIL);
+	    }
+	  // store the actual byte length we received
+	  bf_being_received->bytecount = len;
+	  bf_being_received->dirty = 1;
+ 
+	  //  cout << __FILE__ << " " << __LINE__ << " waiting for write thread " << endl;
+	  pthread_mutex_lock(&M_done);
+	  // and switch the buffers
+	  bf_temp = bf_being_received;
+	  bf_being_received = bf_being_written;
+	  bf_being_written = bf_temp;
+	  bf_being_written->role = ROLE_WRITTEN;
+	  bf_being_received->role = ROLE_RECEIVED;
+	      
+	  //	  cout << __FILE__ << " " << __LINE__ << " switching buffers " << bf_being_received << "  " << bf_being_received << endl;
+	  pthread_mutex_unlock(&M_write);
+	  
+	  i = htonl(CTRL_REMOTESUCCESS);
+	  writen (dd_fd, (char *)&i, sizeof(int));
+	  
+	  break;
+
+	case CTRL_CLOSE:
+	  i = htonl(CTRL_REMOTESUCCESS);
+	  writen (dd_fd, (char *)&i, sizeof(int));
+	  close ( dd_fd);
+	  go_on = 0;
+	  break;
+	  
+	}
+		  
+    }
+  
+  return 0;
+}
+
+
+
+void *writebuffers ( void * arg)
+{
+
+  while(1)
+    {
+
+      pthread_mutex_lock(&M_write);
+
+      pthread_mutex_lock(&M_cout);
+      //cout << __LINE__ << "  " << __FILE__ << " write thread unlocked  " <<  endl;
+      pthread_mutex_unlock(&M_cout);
+
+      int blockcount = ( bf_being_written->bytecount + BUFFERBLOCKSIZE -1)/BUFFERBLOCKSIZE;
+      int bytecount = blockcount*BUFFERBLOCKSIZE;
+      
+      pthread_mutex_lock(&M_cout);
+      //cout << __LINE__ << "  " << __FILE__ << " write thread unlocked, block count " << blockcount <<  endl;
+      pthread_mutex_unlock(&M_cout);
+
+      int bytes = writen ( output_fd, (char *) bf_being_written->bf , bytecount );
+      if ( bytes != bytecount)
+	{
+	  pthread_mutex_lock(&M_cout);
+	  cout << __LINE__ << "  " << __FILE__ << " write error " << bytes << "  " << bytecount <<  endl;
+	  pthread_mutex_unlock(&M_cout);
+	  bf_being_written->dirty = -1;  // mark as "error"
+	}
+      else
+	{
+	  //      usleep(1000000);
+	  bf_being_written->dirty = 0;
+	}
+      //      bytes = writen ( fd, (char *) buffers[i].bf , bytecount );
+      pthread_mutex_unlock(&M_done);
+      
+    }
+  return 0;
+}
+
+
+
+
+int readn (int fd, char *ptr, int nbytes)
+{
+
+  int nread, nleft;
+  //int nleft, nread;
+  nleft = nbytes;
+  while ( nleft>0 )
+    {
+      nread = read (fd, ptr, nleft);
+      if ( nread <= 0 ) 
+	{
+	  return nread;
+	}
+
+#ifdef FRAGMENTMONITORING
+      history[hpos++] = nread;
+#endif
+      nleft -= nread;
+      ptr += nread;
+    }
+
+#ifdef FRAGMENTMONITORING
+  if ( hpos >1 ) 
+    {
+      cout << "Fragmented transfer of " << nbytes << "bytes: ";
+      for ( int i=0; i<hpos; i++)
+	{
+	  cout << " " << history[i]<< ",";
+	}
+      cout << endl;
+    }
+#endif
+  return (nbytes-nleft);
+}
+  
+int writen (int fd, char *ptr, int nbytes)
+{
+  int nleft, nwritten;
+  nleft = nbytes;
+  while ( nleft>0 )
+    {
+      nwritten = write (fd, ptr, nleft);
+      if ( nwritten < 0 ) 
+	return nwritten;
+
+      nleft -= nwritten;
+      ptr += nwritten;
+    }
+  return (nbytes-nleft);
+}
+
+
+in_addr_t find_address_from_interface(const char *interface)
+{
+  int fd;
+  struct ifreq ifr;
+
+  // check the no one plays tricks with us...
+  if ( strlen(interface) >= IFNAMSIZ)
+    {
+      cerr << " Interface name too long, ignoring "<< endl;
+      return htonl(INADDR_ANY);
+    }
+  
+  fd = socket(AF_INET, SOCK_DGRAM, 0);
+
+  // I want to find an IPv4 IP address
+  ifr.ifr_addr.sa_family = AF_INET;
+
+  // I want IP address attached to "interface"
+  strncpy(ifr.ifr_name, interface, IFNAMSIZ-1);
+
+  ioctl(fd, SIOCGIFADDR, &ifr);
+
+  close(fd);
+  in_addr_t a =  ((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr;
+
+  if (verbose)  cout << "  binding to address " << inet_ntoa(  ((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr ) << endl;
+  return a;
+}
+
+
+
+void cleanup( const int exitstatus)
+{
+  close (sockfd);
+  close (dd_fd);
+
+  exit(exitstatus);
+}
+    


### PR DESCRIPTION
This PR adds three different changes:

1) the implementation of a new server-based file writing, where the data are written to a remote server.
    this is useful when you have many instances of RCDAQ running, and you want the changes to end up
    on a central file server. It will also allow you to finesse a ssh tunnel to write a small amount of data directly 
    on a remote server that you connect this way. I use this to have data end up on my development machine directly.

2) implementation of a "fast end" mechanism. This is chiefly in use at the sPHENIX experiment where we have a 
    large number  of RCDAQ instances that are controlled in a tight loop. The normal "end" operation works
    synchronously; that it, the call returns when the run is ended, and all data have been written out. 
    The "fast end" merely requests that the run should be ended and will return immediately.
    In order to preserve synchronicity, the _next_ operation will wait for the run to be fully ended.

3) a slight change in the web socket interfaces. Any new client requests a "full update" in order to be able to
    update all fields to their current values once. From there on, only updated changes are sent. Before, the full updates
    were sent as a broadcast, that is, to all clients. Now they are sent only to the client that sent the request. 
