### PR TITLE
eliminating warnings caused by "register" declarations 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ allsources = \
 AM_LDFLAGS = -L$(libdir) -L$(ONLINE_MAIN)/lib
 
 AM_CXXFLAGS = -I$(includedir) -I$(ONLINE_MAIN)/include $(RPC_INCLUDE)
+AM_CPPFLAGS = -I$(includedir) -I$(ONLINE_MAIN)/include $(RPC_INCLUDE)
 
 noinst_HEADERS = \
   EvtConstants.h \
@@ -56,9 +57,9 @@ RPCGEN = rpcgen
 
 
 BUILT_SOURCES = \
-        rcdaq_rpc_clnt.cc \
-        rcdaq_rpc_svc.cc \
-        rcdaq_rpc_xdr.cc \
+        rcdaq_rpc_clnt.c \
+        rcdaq_rpc_svc.c \
+        rcdaq_rpc_xdr.c \
         rcdaq_rpc.h
 
 
@@ -105,7 +106,7 @@ endif
 
 librcdaq_la_CPPFLAGS = -DHTMLFILE=\"$(html_INDEX)\" -DHTMLDIR=\"$(htmldir)\"
 
-librcdaqutils_la_SOURCES = rcdaq_rpc_clnt.cc rcdaq_rpc_xdr.cc parseargument.cc
+librcdaqutils_la_SOURCES = rcdaq_rpc_clnt.cc rcdaq_rpc_xdr.c parseargument.cc
 
 librcdaqplugin_example_la_SOURCES = daq_device_pluginexample.cc example_plugin.cc
 
@@ -138,19 +139,19 @@ sfs_LDADD = -lpthread
 
 
 
-rcdaq_rpc_clnt.cc : $(srcdir)/rcdaq_rpc.x
+rcdaq_rpc_clnt.c : $(srcdir)/rcdaq_rpc.x
 	cp  $(srcdir)/rcdaq_rpc.x ./rcdaq_rpc.xx
 	$(RPCGEN) -l rcdaq_rpc.xx  > $@
 	rm rcdaq_rpc.xx
 
 
-rcdaq_rpc_svc.cc : $(srcdir)/rcdaq_rpc.x
+rcdaq_rpc_svc.c : $(srcdir)/rcdaq_rpc.x
 	cp  $(srcdir)/rcdaq_rpc.x ./rcdaq_rpc.xx
 	$(RPCGEN) -m rcdaq_rpc.xx  > $@
 	rm rcdaq_rpc.xx
 
 
-rcdaq_rpc_xdr.cc : $(srcdir)/rcdaq_rpc.x
+rcdaq_rpc_xdr.c : $(srcdir)/rcdaq_rpc.x
 	cp  $(srcdir)/rcdaq_rpc.x ./rcdaq_rpc.xx
 	$(RPCGEN)  -c  rcdaq_rpc.xx  > $@
 	rm rcdaq_rpc.xx

--- a/mongoose.cc
+++ b/mongoose.cc
@@ -1269,7 +1269,7 @@ void MD5_Init(MD5_CTX *ctx) {
 }
 
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]) {
-   register uint32_t a, b, c, d;
+   uint32_t a, b, c, d;
    
    a = buf[0];
    b = buf[1];

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -45,7 +45,7 @@ std::vector<RCDAQPlugin *> pluginlist;
 
 static unsigned long  my_servernumber = 0;
 
-void rcdaq_1(struct svc_req *rqstp, SVCXPRT *transp);
+extern "C"  void rcdaq_1(struct svc_req *rqstp, SVCXPRT *transp);
 
 static int pid_fd = 0;
 

--- a/simpleRandom.cc
+++ b/simpleRandom.cc
@@ -133,7 +133,7 @@ simpleRandom::xMD5Final(byte bdigest[16], struct xMD5Context *ctx)
 void
 simpleRandom::xMD5Transform(word32 buf[4], word32 const in[16])
 {
-        register word32 a, b, c, d;
+        word32 a, b, c, d;
 
         a = buf[0];
         b = buf[1];


### PR DESCRIPTION
1) The source files generated with rpcgen are meant to be c files. I compiled them with the c++ compiler until now. They contain a few "register" declarations that the c++ compiler doesn't like. Obviously I cannot do anything about the way rpcgen does its job. I converted the Makefile to actually use them as .c files as intended, and compile them with the c compiler. All clear now.
2) in the same spirit, I removed register declarations from 2 more .cc source files. 