### PR TITLE
cumulative update - "immediate" end-run handling, multiple rcdaq instances

### DIFF
--- a/rcdaq.h
+++ b/rcdaq.h
@@ -24,7 +24,7 @@ int device_init();
 int device_endrun();
 int readout(const int etype);
 int rearm(const int etype);
-int rcdaq_init(pthread_mutex_t &M );
+int rcdaq_init(const int, pthread_mutex_t &M );
 int add_readoutdevice( daq_device *d);
 
 int daq_begin(const int irun,std::ostream& os = std::cout );

--- a/rcdaq_client.cc
+++ b/rcdaq_client.cc
@@ -17,7 +17,7 @@ CLIENT *clnt;
 int  verbose_flag = 0;
 
 void
-rcdaq_client_Init(char *host, const int servernumber)
+rcdaq_client_Init(const char *host, const int servernumber)
 {
 
 
@@ -229,23 +229,31 @@ int command_execute( int argc, char **argv)
     }
 
   
-  char lh[] = "localhost";
-  char *host = lh;
+  std::string rcdaqhost;
+  std::string host = "localhost";
     
   if ( getenv("RCDAQHOST")  )
     {
-      host = getenv("RCDAQHOST");
+      rcdaqhost = getenv("RCDAQHOST");
+      istringstream ss(rcdaqhost);
+      string token;
+      std::getline(ss, token, ':');
+      if ( token.size())
+	{
+	  host = token;
+	}
+
+      std::getline(ss, token, ':');
+      if ( token.size())
+	{
+	  servernumber=std::stoi(token);
+	}
     }
 
-  if ( getenv("RCDAQSERVERNUMBER")  )
-    {
-      servernumber = atoi(getenv("RCDAQSERVERNUMBER"));
-    }
-
-  //  std::cout << "Server number is " << servernumber << std::endl;
+  //  std::cout << "hoat " << host << " Server number is " << servernumber << std::endl;
 
   
-  rcdaq_client_Init (host,servernumber);
+  rcdaq_client_Init (host.c_str(),servernumber);
   
   ab.action = 0;
   ab.value  = 0;

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -65,12 +65,6 @@ void sig_handler(int i)
 
 //-------------------------------------------------------------
 
-int server_setup(int argc, char **argv)
-{
-  return 0;
-}
-
-//-------------------------------------------------------------
 
 void plugin_register(RCDAQPlugin * p )
 {
@@ -1022,11 +1016,7 @@ main (int argc, char **argv)
   
   pthread_mutex_init(&M_output, 0); 
 
-  rcdaq_init( M_output);
-
-
-  server_setup(argc, argv);
-
+  rcdaq_init( servernumber, M_output);
 
   my_servernumber = RCDAQ+servernumber;  // remember who we are for later
 
@@ -1044,9 +1034,9 @@ main (int argc, char **argv)
     exit(1);
   }
 
-  char hostname[1024];
-  gethostname(hostname, 1024);
-  daq_set_name(hostname);
+  // char hostname[1024];
+  // gethostname(hostname, 1024);
+  // daq_set_name(hostname);
 
   svc_run ();
   fprintf (stderr, "%s", "svc_run returned");


### PR DESCRIPTION
implemented a better "immediate" end-run that avoids the failure that we experience with the digitizer plugin
Added consistent support for multiple rcdaq instances on the same node. One can now define RCDAQHOST to be localhost:n where n is the "server number", e.g.
export RCDAQHOST=localhost:1
