### PR TITLE
prevent run type / file rule changes when a run is in progress

### DIFF
--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -967,8 +967,14 @@ int getRunNumberFromApp()
 
 
 
-int daq_set_filerule(const char *rule)
+int daq_set_filerule(const char *rule , std::ostream& os)
 {
+  if ( DAQ_RUNNING ) 
+    {
+      os << MyHostName << "Run is active" << endl;;
+      return -1;
+    }
+
   TheFileRule = rule;
   return 0;
 }
@@ -1033,6 +1039,13 @@ int daq_get_mqtt_host(std::ostream& os)
 // this is selecting from any of the existing run types 
 int daq_setruntype(const char *type, std::ostream& os )
 {
+
+  if ( DAQ_RUNNING ) 
+    {
+      os << MyHostName << "Run is active" << endl;;
+      return -1;
+    }
+
   std::string _type = type;
   std::map <string,string>::const_iterator iter = RunTypes.begin();
   for ( ; iter != RunTypes.end(); ++iter)

--- a/rcdaq.h
+++ b/rcdaq.h
@@ -43,7 +43,7 @@ int daq_write_runnumberfile(const int run);
 int daq_set_runnumberfile(const char *file, const int flag);
 int daq_set_runnumberApp(const char *file, const int flag);
 
-int daq_set_filerule(const char *rule);
+int daq_set_filerule(const char *rule, std::ostream& os = std::cout);
 
 int daq_setruntype(const char *type, std::ostream& os = std::cout);
 int daq_getruntype(const int flag, std::ostream& os = std::cout);

--- a/rcdaq_server.cc
+++ b/rcdaq_server.cc
@@ -566,7 +566,16 @@ shortResult * r_action_1_svc(actionblock *ab, struct svc_req *rqstp)
       break;
 
     case DAQ_SETFILERULE:
-      daq_set_filerule(ab->spar);
+      result.status = daq_set_filerule(ab->spar, outputstream);
+      if ( result.status)
+	{
+	  outputstream.str().copy(resultstring,outputstream.str().size());
+	  resultstring[outputstream.str().size()] = 0;
+	  result.str = resultstring;
+	  result.content = 1;
+	}
+      pthread_mutex_unlock(&M_output);
+      return &result;
       break;
 
     case DAQ_SETNAME:


### PR DESCRIPTION
This used to be a RCDAQ feature in the past but is no more - before the advent on file roll-overs, one could change the file rule *while a run was in progress*. It would take effect at the next RUN. But now it took place at the next file rollover, which is of course undesired. 
I fixed it so that one gets an error when on tries to change either the run type or the file rule directly while a run is active.  