### PR TITLE
avoiding leaving last file id in fd_map a after run ends

### DIFF
--- a/rcdaq.cc
+++ b/rcdaq.cc
@@ -306,15 +306,19 @@ int close_fd_except_active( const int fd)
 
   coutfl << "in close_fd_except_active for fd " << fd << endl;
   
-  for ( auto ifd = fd_map.begin(); ifd != fd_map.end(); ifd++)
+  for ( auto ifd = fd_map.begin(); ifd != fd_map.end(); )
     {
       coutfl << "fd " << (*ifd).first << " has " <<  (*ifd).second << " users"  << endl;
       if ( (*ifd).first != fd && (*ifd).second == 0)
-	{
-	  coutfl << "removed fd " << (*ifd).first << endl;
-	  close ( (*ifd).first );
-	  ifd = fd_map.erase(ifd);
-	}
+      {
+        coutfl << "removed fd " << (*ifd).first << endl;
+        close ( (*ifd).first );
+        ifd = fd_map.erase(ifd);
+      }
+      else
+      {
+        ++ifd;
+      }
     }
   pthread_mutex_unlock( &OutfileManagementSem);
   
@@ -1681,11 +1685,9 @@ int daq_end(std::ostream& os)
 
 
 	  coutfl << "closing outfile.. " << endl;
+	  outfile_fd = 0; // mark all files inactive
 	  close_fd_except_active(outfile_fd);
-	  
-	  close (outfile_fd);
 	  daq_generate_json(1);
-	  outfile_fd = 0;
 	}
       file_is_open = 0;
 


### PR DESCRIPTION
Following the Friday debug session, it appears the failure mode of random loss of the FELIX endpoints points to two problems, for which the fix is being proposed here: 

1. In `daq_end(std::ostream& os)`, the last file `fd` is closed outside `close_fd_except_active( const int fd)`. Therefore, its `fd` is still marked as open and 0 user in `fd_map`. That is why in the second run, any new file handle that happens to falls into the last `fd` ID would get closed unexpectedly at the first `close_fd_except_active( const int fd)` call, which is when the first raw data file get closed. 

2. The second problem appears to be `ifd = fd_map.erase(ifd);` will advance `ifd `, which is then advanced again in `ifd++` of the for-loop. This has the potential of skip one file close, although this would not cause a crash, just stale opened files. 

Testing on TPC for 12 runs seem OK